### PR TITLE
feat: Extract/Copy single image

### DIFF
--- a/src/main/java/org/pdflite/controller/ContextMenuHandler.java
+++ b/src/main/java/org/pdflite/controller/ContextMenuHandler.java
@@ -11,45 +11,59 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import javafx.embed.swing.SwingFXUtils;
+import javafx.scene.image.Image;
+import org.pdflite.model.ImageInfo;
+import static org.pdflite.util.Constants.LOW_RENDER_SCALE;
+import org.pdflite.util.ImageExtractor;
 
 /**
  * Handles context menu operations with CORRECT coordinate mapping.
- * 
- * <p><b>Implementation Notes:</b></p>
+ *
+ * <p>
+ * <b>Implementation Notes:</b></p>
  * <ul>
- *   <li>Uses {@link CoordinateConverter} for proper canvas-to-PDF coordinate transformation</li>
- *   <li>Implements Knowledge Base Section III coordinate conversion pipeline</li>
- *   <li>Supports text extraction via {@link PDFTextStripperByArea} (Y=top coords)</li>
- *   <li>TODO: Image extraction via PDFStreamEngine (Y=bottom coords)</li>
+ * <li>Uses {@link CoordinateConverter} for proper canvas-to-PDF coordinate
+ * transformation</li>
+ * <li>Implements Knowledge Base Section III coordinate conversion pipeline</li>
+ * <li>Supports text extraction via {@link PDFTextStripperByArea} (Y=top
+ * coords)</li>
+ * <li>TODO: Image extraction via PDFStreamEngine (Y=bottom coords)</li>
  * </ul>
- * 
+ *
  * @see CoordinateConverter
  * @see <a href="../../../docs/knowledge.md">Knowledge Base</a>
  */
 public class ContextMenuHandler {
+
     private static final Logger logger = LoggerFactory.getLogger(ContextMenuHandler.class);
-    
+
     // Selection state
     private SelectionInfo currentSelection;
-    
+
+    private List<ImageInfo> currentPageImages = new ArrayList<>();
+    private ImageInfo currentImageUnderCursor;
+
     public ContextMenuHandler() {
         logger.info("ContextMenuHandler initialized!");
     }
-    
+
     /**
      * Analyzes rectangular selection area on PDF page.
-     * 
-     * <p><b>Coordinate Conversion Pipeline:</b></p>
+     *
+     * <p>
+     * <b>Coordinate Conversion Pipeline:</b></p>
      * <ol>
-     *   <li>Input: Canvas coordinates (pixels, Y=top)</li>
-     *   <li>Normalize: Create bounding box (x, y, width, height)</li>
-     *   <li>Convert: Apply scale factor (zoom * 150/72)</li>
-     *   <li>Extract: Pass to PDFTextStripperByArea (expects Y=top)</li>
+     * <li>Input: Canvas coordinates (pixels, Y=top)</li>
+     * <li>Normalize: Create bounding box (x, y, width, height)</li>
+     * <li>Convert: Apply scale factor (zoom * 150/72)</li>
+     * <li>Extract: Pass to PDFTextStripperByArea (expects Y=top)</li>
      * </ol>
-     * 
+     *
      * @param document The PDF document
      * @param pageIndex Zero-based page index
      * @param canvasX1 Canvas X coordinate of first corner (pixels)
@@ -59,101 +73,96 @@ public class ContextMenuHandler {
      * @param zoom Current zoom level (e.g., 1.0 = 100%)
      */
     public void analyzeSelection(PDFDocument document, int pageIndex,
-                                double canvasX1, double canvasY1,
-                                double canvasX2, double canvasY2,
-                                double zoom) {
-        
+            double canvasX1, double canvasY1,
+            double canvasX2, double canvasY2,
+            double zoom) {
+
         if (document == null || document.getDocument() == null) {
             logger.warn("Analysis aborted: document is null");
             return;
         }
-        
+
         try {
             PDPage page = document.getDocument().getPage(pageIndex);
             PDRectangle cropBox = page.getCropBox();
             float pageWidth = cropBox.getWidth();
             float pageHeight = cropBox.getHeight();
-            
+
             // Normalize canvas coordinates (create bounding box)
             double x1 = Math.min(canvasX1, canvasX2);
             double y1 = Math.min(canvasY1, canvasY2);
             double width = Math.abs(canvasX2 - canvasX1);
             double height = Math.abs(canvasY2 - canvasY1);
-            
+
             // Convert to PDF Java Points (Y=top)
             Rectangle2D.Float pdfRect = CoordinateConverter.canvasToPdfJavaRect(
-                x1, y1, width, height, pageHeight, zoom
+                    x1, y1, width, height, pageHeight, zoom
             );
-            
-            
+
             // Validate coordinates
             if (!CoordinateConverter.isValidPdfCoordinate(
                     pdfRect.x, pdfRect.y, pageWidth, pageHeight)) {
-                logger.warn("Coordinates outside page bounds!");
+                //logger.warn("Coordinates outside page bounds!");
             }
-            
+
             // Extract text
             currentSelection = extractTextFromRegion(page, pdfRect, pageIndex);
-            
+
             if (currentSelection.hasText()) {
-                logger.info("Length:   {} characters",currentSelection.getText().length());
-                
-                String preview = currentSelection.getText().substring(0, 
-                    Math.min(50, currentSelection.getText().length()));
+                //logger.info("Length:   {} characters",currentSelection.getText().length());
+
+                String preview = currentSelection.getText().substring(0,
+                        Math.min(50, currentSelection.getText().length()));
             } else {
                 logger.info("No text found in selection");
             }
-            
+
         } catch (IOException e) {
             logger.error("Error analyzing selection: {}", e.getMessage(), e);
         }
     }
-    
+
     /**
      * Extracts text from a PDF Java rectangle (Y=top coordinates).
-     * 
-     * <p><b>PDFBox Requirements:</b></p>
+     *
+     * <p>
+     * <b>PDFBox Requirements:</b></p>
      * <ul>
-     *   <li>Input rectangle MUST use Java/AWT coordinates (Y=0 at top)</li>
-     *   <li>Use {@code setSortByPosition(true)} for natural reading order</li>
-     *   <li>Use {@code setShouldSeparateByBeads(false)} for area extraction</li>
+     * <li>Input rectangle MUST use Java/AWT coordinates (Y=0 at top)</li>
+     * <li>Use {@code setSortByPosition(true)} for natural reading order</li>
+     * <li>Use {@code setShouldSeparateByBeads(false)} for area extraction</li>
      * </ul>
-     * 
+     *
      * @param page The PDF page
      * @param rect Rectangle in PDF Java coordinates (Y=top)
      * @param pageIndex Page index for tracking
      * @return SelectionInfo containing extracted text
      * @throws IOException if extraction fails
      */
-    private SelectionInfo extractTextFromRegion(PDPage page, Rectangle2D.Float rect, int pageIndex) 
+    private SelectionInfo extractTextFromRegion(PDPage page, Rectangle2D.Float rect, int pageIndex)
             throws IOException {
-        
+
         //logger.debug("Extracting text from region: ({:.2f},{:.2f})+{:.2f}x{:.2f}", rect.x, rect.y, rect.width, rect.height);
-        
         PDFTextStripperByArea stripper = new PDFTextStripperByArea();
-        
-        // Knowledge Base Section 1: Text Extraction Configuration
+
         stripper.setSortByPosition(true);
         stripper.setShouldSeparateByBeads(false);
-        
-        // Add region with Java coordinates (Y=top)
+
         String regionName = "selection";
         stripper.addRegion(regionName, rect);
         stripper.extractRegions(page);
-        
+
         String text = stripper.getTextForRegion(regionName);
         String cleanedText = (text != null) ? text.trim() : "";
-        
-        logger.debug("Extracted {} characters from region", cleanedText.length());
-        
+
         return new SelectionInfo(
-            pageIndex,
-            rect,
-            cleanedText,
-            new ArrayList<>() // TODO: Extract images
+                pageIndex,
+                rect,
+                cleanedText,
+                new ArrayList<>() // TODO: Extract images
         );
     }
-    
+
     /**
      * Copies extracted text to system clipboard.
      */
@@ -162,61 +171,172 @@ public class ContextMenuHandler {
             ClipboardContent content = new ClipboardContent();
             content.putString(currentSelection.getText());
             Clipboard.getSystemClipboard().setContent(content);
-            
-            logger.info("Copied {} characters to clipboard", 
-                currentSelection.getText().length());
+
+            //logger.info("Copied {} characters to clipboard",currentSelection.getText().length());
         } else {
             logger.warn("No text to copy");
         }
     }
-    
+
     /**
      * Checks if text is available at last analyzed position.
-     * @return 
+     *
+     * @return
      */
     public boolean hasTextAtPosition() {
         return currentSelection != null && currentSelection.hasText();
     }
-    
+
     /**
      * Gets current selection info (for debugging).
-     * @return 
+     *
+     * @return
      */
     public SelectionInfo getCurrentSelection() {
         return currentSelection;
     }
-    
+
     /**
      * Inner class to hold selection information.
      */
     public static class SelectionInfo {
+
         private final int pageIndex;
         private final Rectangle2D.Float pdfRect;
         private final String text;
         private final List<Object> images; // TODO: Implement image extraction
-        
-        public SelectionInfo(int pageIndex, Rectangle2D.Float pdfRect, 
-                           String text, List<Object> images) {
+
+        public SelectionInfo(int pageIndex, Rectangle2D.Float pdfRect,
+                String text, List<Object> images) {
             this.pageIndex = pageIndex;
             this.pdfRect = pdfRect;
             this.text = text;
             this.images = images;
         }
-        
+
         public boolean hasText() {
             return text != null && !text.isEmpty();
         }
-        
+
         public String getText() {
             return text;
         }
-        
+
         public int getPageIndex() {
             return pageIndex;
         }
-        
+
         public Rectangle2D.Float getPdfRect() {
             return pdfRect;
         }
+    }
+
+    /**
+     * Analyzes if cursor is over an image (for context menu).
+     *
+     * <p>
+     * <b>Algorithm:</b></p>
+     * <ol>
+     * <li>Extract all images from current page</li>
+     * <li>Convert image bounds from PDF (Y=bottom) to Canvas (Y=top)</li>
+     * <li>Check if cursor point intersects with any image bounds</li>
+     * </ol>
+     */
+    public void analyzeCursorForImage(PDFDocument document, int pageIndex,
+            double canvasX, double canvasY,
+            double zoom) {
+
+        currentImageUnderCursor = null;
+
+        if (document == null || document.getDocument() == null) {
+            return;
+        }
+
+        try {
+            PDPage page = document.getDocument().getPage(pageIndex);
+            PDRectangle cropBox = page.getCropBox();
+            float pageHeight = cropBox.getHeight();
+
+            // Extract images if not cached
+            if (currentPageImages.isEmpty()) {
+                ImageExtractor extractor = new ImageExtractor();
+                currentPageImages = extractor.extractImages(page, pageIndex);
+                logger.info("║ Extracted {} images from page {}                      ║",
+                        currentPageImages.size(), pageIndex + 1);
+            }
+
+            // Check each image
+            for (int i = 0; i < currentPageImages.size(); i++) {
+                ImageInfo imageInfo = currentPageImages.get(i);
+
+                // Convert to canvas coords
+                Rectangle2D.Float canvasRect = CoordinateConverter.pdfToCanvasRect(
+                        imageInfo.getXPosition(),
+                        imageInfo.getYPosition(),
+                        imageInfo.getWidth(),
+                        imageInfo.getHeight(),
+                        pageHeight,
+                        zoom
+                );
+
+                // Hit-test
+                boolean hit = canvasRect.contains(canvasX, canvasY);
+                logger.info("Hit-test:    {} (cursor in bounds: {})",
+                        hit ? "HIT" : "MISS",
+                        hit ? "YES" : "NO");
+
+                if (hit) {
+                    currentImageUnderCursor = imageInfo;
+                    logger.info("FOUND: Image #{} contains cursor!", i + 1);
+                    break;
+                }
+            }
+
+            if (currentImageUnderCursor == null) {
+                // return noting
+            } else {
+                // return nothing
+            }
+
+        } catch (Exception e) {
+            logger.error("ERROR: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Copies image under cursor to clipboard.
+     */
+    public void handleCopyImage() {
+        if (currentImageUnderCursor != null) {
+            BufferedImage bufferedImage = currentImageUnderCursor.getImage();
+
+            // Convert BufferedImage to JavaFX Image
+            Image fxImage = SwingFXUtils.toFXImage(bufferedImage, null);
+
+            // Put to clipboard
+            ClipboardContent content = new ClipboardContent();
+            content.putImage(fxImage);
+            Clipboard.getSystemClipboard().setContent(content);
+
+            logger.info("Copied image ({}x{}) to clipboard",
+                    bufferedImage.getWidth(), bufferedImage.getHeight());
+        } else {
+            logger.warn("No image under cursor to copy");
+        }
+    }
+
+    /**
+     * Checks if cursor is currently over an image.
+     */
+    public boolean hasImageAtPosition() {
+        return currentImageUnderCursor != null;
+    }
+
+    /**
+     * Clears image cache (call when page changes).
+     */
+    public void clearImageCache() {
+        currentPageImages.clear();
+        currentImageUnderCursor = null;
     }
 }

--- a/src/main/java/org/pdflite/controller/PageRenderer.java
+++ b/src/main/java/org/pdflite/controller/PageRenderer.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import org.pdflite.view.ContextMenuPane;
 
 /**
@@ -240,34 +242,37 @@ public class PageRenderer {
     imageView.setCache(true);
     
     imageView.setPickOnBounds(false);
+    imageView.setMouseTransparent(false);
 
-    // Create annotation layer on top of the image
+    // Create annotation layer
     AnnotationLayer annotationLayer = new AnnotationLayer(image.getWidth(), image.getHeight());
-    if (highlightModeActive) {
-        annotationLayer.setAnnotationMode(AnnotationLayer.AnnotationMode.HIGHLIGHT);
-    }
-    
     annotationLayer.setPickOnBounds(false);
+    annotationLayer.setOnContextMenuRequested(null);
+    annotationLayer.addEventFilter(MouseEvent.MOUSE_PRESSED, event -> {
+        if (event.getButton() == MouseButton.SECONDARY) {
+            // return nothing
+        }
+    });
 
+    // Create context menu pane
     ContextMenuPane contextPane = new ContextMenuPane(contextMenuHandler);
     contextPane.setDocumentInfo(currentDocument, pageIndex, currentZoom);
     contextPane.setPrefSize(image.getWidth(), image.getHeight());
     contextPane.setMaxSize(image.getWidth(), image.getHeight());
+    
+    contextPane.toFront();
 
-    /**
-     * IMPORTANT NOTE
-     */
     // Stack layers: Image (bottom) -> Annotation -> ContextMenu (top)
     StackPane imageStack = new StackPane(imageView, annotationLayer, contextPane);
     imageStack.setAlignment(Pos.CENTER);
+    
+    imageStack.setPickOnBounds(false);
 
-    // Replace placeholder with actual image
     if (!pageBox.getChildren().isEmpty()) {
         pageBox.getChildren().set(0, imageStack);
     }
 
-    logger.debug("Page {} displayed with context menu support (layers: Image -> Annotation -> Context)", 
-        pageIndex + 1);
+    logger.debug("Page {} displayed - Context menu layer active", pageIndex + 1);
 }
 
     /**

--- a/src/main/java/org/pdflite/model/ImageInfo.java
+++ b/src/main/java/org/pdflite/model/ImageInfo.java
@@ -1,0 +1,49 @@
+package org.pdflite.model;
+
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+
+/**
+ * Data model for PDF images with coordinate information.
+ * 
+ * <p><b>Coordinate System:</b></p>
+ * <ul>
+ *   <li>xPosition, yPosition: PDF coordinates (Y=bottom)</li>
+ *   <li>Canvas coordinates calculated on-demand via converter</li>
+ * </ul>
+ * 
+ * @see <a href="../../../docs/knowledge_2.md">Knowledge Base - Image Extraction</a>
+ */
+public class ImageInfo {
+    private final int pageIndex;
+    private final float xPosition;      // PDF coordinates (Y=bottom)
+    private final float yPosition;      // PDF coordinates (Y=bottom)
+    private final float width;          // Rendered width in PDF points
+    private final float height;         // Rendered height in PDF points
+    private final BufferedImage image;  // Actual image data for clipboard
+    
+    public ImageInfo(int pageIndex, float xPosition, float yPosition,
+                    float width, float height, BufferedImage image) {
+        this.pageIndex = pageIndex;
+        this.xPosition = xPosition;
+        this.yPosition = yPosition;
+        this.width = width;
+        this.height = height;
+        this.image = image;
+    }
+    
+    /**
+     * Gets bounding box in PDF coordinates (Y=bottom).
+     */
+    public Rectangle2D.Float getPdfBounds() {
+        return new Rectangle2D.Float(xPosition, yPosition, width, height);
+    }
+    
+    // Getters
+    public int getPageIndex() { return pageIndex; }
+    public float getXPosition() { return xPosition; }
+    public float getYPosition() { return yPosition; }
+    public float getWidth() { return width; }
+    public float getHeight() { return height; }
+    public BufferedImage getImage() { return image; }
+}

--- a/src/main/java/org/pdflite/util/CoordinateConverter.java
+++ b/src/main/java/org/pdflite/util/CoordinateConverter.java
@@ -8,72 +8,83 @@ import org.slf4j.LoggerFactory;
 import static org.pdflite.util.Constants.LOW_RENDER_SCALE;
 
 /**
- * Utility for converting coordinates between Canvas/GUI and PDF coordinate systems.
- * 
- * <p><b>Coordinate Systems:</b></p>
+ * Utility for converting coordinates between Canvas/GUI and PDF coordinate
+ * systems.
+ *
+ * <p>
+ * <b>Coordinate Systems:</b></p>
  * <ul>
- *   <li><b>Canvas/GUI:</b> Origin (0,0) at TOP-LEFT, Y increases downward, units in PIXELS</li>
- *   <li><b>PDF User Space:</b> Origin (0,0) at BOTTOM-LEFT, Y increases upward, units in POINTS (1/72 inch)</li>
- *   <li><b>PDF Java/AWT:</b> Origin (0,0) at TOP-LEFT, Y increases downward, units in POINTS</li>
+ * <li><b>Canvas/GUI:</b> Origin (0,0) at TOP-LEFT, Y increases downward, units
+ * in PIXELS</li>
+ * <li><b>PDF User Space:</b> Origin (0,0) at BOTTOM-LEFT, Y increases upward,
+ * units in POINTS (1/72 inch)</li>
+ * <li><b>PDF Java/AWT:</b> Origin (0,0) at TOP-LEFT, Y increases downward,
+ * units in POINTS</li>
  * </ul>
- * 
- * <p><b>Knowledge Base Reference:</b></p>
+ *
+ * <p>
+ * <b>Knowledge Base Reference:</b></p>
  * <pre>
  * Section III - Coordinate Conversion:
  * Y_pdf_java_points = (H_pdf - (Y_canvas / scale))
  * where scale = zoom * LOW_RENDER_SCALE (zoom * 150/72)
  * </pre>
- * 
+ *
  * @see <a href="../../../docs/knowledge.md">Knowledge Base - Section III</a>
  */
 public class CoordinateConverter {
+
     private static final Logger logger = LoggerFactory.getLogger(CoordinateConverter.class);
-    
+
     /**
      * Converts canvas/GUI rectangle to PDF Java/AWT rectangle (Y=top).
-     * 
-     * <p><b>Algorithm:</b></p>
+     *
+     * <p>
+     * <b>Algorithm:</b></p>
      * <ol>
-     *   <li>Calculate final scale: {@code scale = zoom * LOW_RENDER_SCALE}</li>
-     *   <li>Convert X: {@code pdfX = canvasX / scale}</li>
-     *   <li>Convert Y: {@code pdfY = canvasY / scale} (already Y=top)</li>
-     *   <li>Convert dimensions: {@code pdfWidth/Height = canvasWidth/Height / scale}</li>
+     * <li>Calculate final scale: {@code scale = zoom * LOW_RENDER_SCALE}</li>
+     * <li>Convert X: {@code pdfX = canvasX / scale}</li>
+     * <li>Convert Y: {@code pdfY = canvasY / scale} (already Y=top)</li>
+     * <li>Convert dimensions:
+     * {@code pdfWidth/Height = canvasWidth/Height / scale}</li>
      * </ol>
-     * 
+     *
      * @param canvasX X coordinate on canvas (pixels, origin at top-left)
      * @param canvasY Y coordinate on canvas (pixels, origin at top-left)
      * @param canvasWidth Width of rectangle (pixels)
      * @param canvasHeight Height of rectangle (pixels)
-     * @param pageHeight PDF page height in points (unused for Java coords, kept for API compatibility)
+     * @param pageHeight PDF page height in points (unused for Java coords, kept
+     * for API compatibility)
      * @param zoom Current zoom level (e.g., 1.0, 1.5, 2.0)
-     * @return Rectangle in PDF Java/AWT coordinate system (Y=top, units in points)
+     * @return Rectangle in PDF Java/AWT coordinate system (Y=top, units in
+     * points)
      */
     public static Rectangle2D.Float canvasToPdfJavaRect(
             double canvasX, double canvasY,
             double canvasWidth, double canvasHeight,
             float pageHeight, double zoom) {
-        
+
         // Calculate scale factor (150 DPI / 72 DPI)
         double finalScale = zoom * LOW_RENDER_SCALE;
-        
-        float pdfX = (float)(canvasX / finalScale);
-        float pdfY = (float)(canvasY / finalScale);
-        float pdfWidth = (float)(canvasWidth / finalScale);
-        float pdfHeight = (float)(canvasHeight / finalScale);
-        
+
+        float pdfX = (float) (canvasX / finalScale);
+        float pdfY = (float) (canvasY / finalScale);
+        float pdfWidth = (float) (canvasWidth / finalScale);
+        float pdfHeight = (float) (canvasHeight / finalScale);
+
         // (PDFTextStripperByArea expects Y=top coordinates)
-        
         /**
-        logger.trace("Converted canvas->pdfJava: ({:.2f},{:.2f})+{:.2f}x{:.2f}px @ scale={:.4f} -> ({:.2f},{:.2f})+{:.2f}x{:.2f}pt",
-                canvasX, canvasY, canvasWidth, canvasHeight, finalScale,
-                pdfX, pdfY, pdfWidth, pdfHeight);
-        */
+         * logger.trace("Converted canvas->pdfJava:
+         * ({:.2f},{:.2f})+{:.2f}x{:.2f}px @ scale={:.4f} ->
+         * ({:.2f},{:.2f})+{:.2f}x{:.2f}pt", canvasX, canvasY, canvasWidth,
+         * canvasHeight, finalScale, pdfX, pdfY, pdfWidth, pdfHeight);
+         */
         return new Rectangle2D.Float(pdfX, pdfY, pdfWidth, pdfHeight);
     }
-    
+
     /**
      * Converts single canvas point to PDF Java/AWT point (Y=top).
-     * 
+     *
      * @param canvasX X coordinate on canvas (pixels)
      * @param canvasY Y coordinate on canvas (pixels)
      * @param pageHeight PDF page height (unused, kept for API compatibility)
@@ -83,37 +94,92 @@ public class CoordinateConverter {
     public static Point2D.Float canvasToPdfJavaPoint(
             double canvasX, double canvasY,
             float pageHeight, double zoom) {
-        
+
         double finalScale = zoom * LOW_RENDER_SCALE;
-        
-        float pdfX = (float)(canvasX / finalScale);
-        float pdfY = (float)(canvasY / finalScale);
-        
+
+        float pdfX = (float) (canvasX / finalScale);
+        float pdfY = (float) (canvasY / finalScale);
+
+        /*
         logger.trace("Converted canvas->pdfJava point: ({:.2f},{:.2f})px @ scale={:.4f} -> ({:.2f},{:.2f})pt",
                 canvasX, canvasY, finalScale, pdfX, pdfY);
-        
+         */
         return new Point2D.Float(pdfX, pdfY);
     }
-    
+
+    /**
+     * @param pdfX X in PDF points
+     * @param pdfY Y in PDF points (bottom-origin)
+     * @param pageHeight Page height in PDF points
+     * @param zoom Current zoom level
+     * @return Point in canvas coordinates (pixels, Y=top)
+     */
+    public static Point2D.Float pdfToCanvasPoint(
+            float pdfX, float pdfY,
+            float pageHeight, double zoom) {
+
+        double finalScale = zoom * LOW_RENDER_SCALE;
+
+        // Y-axis inversion: PDF Y=bottom → Canvas Y=top
+        float canvasX = (float) (pdfX * finalScale);
+        float canvasY = (float) ((pageHeight - pdfY) * finalScale);
+
+        /*
+        logger.trace("Converted PDF->Canvas: ({:.2f},{:.2f}) @ page_h={:.2f} → ({:.2f},{:.2f})px",
+                pdfX, pdfY, pageHeight, canvasX, canvasY);
+         */
+        return new Point2D.Float(canvasX, canvasY);
+    }
+
+    /**
+     *
+     * @param pdfX
+     * @param pdfY
+     * @param pdfWidth
+     * @param pdfHeight
+     * @param pageHeight
+     * @param zoom
+     * @return
+     */
+    public static Rectangle2D.Float pdfToCanvasRect(
+            float pdfX, float pdfY, float pdfWidth, float pdfHeight,
+            float pageHeight, double zoom) {
+
+        double finalScale = zoom * LOW_RENDER_SCALE;
+
+        // Convert coordinates
+        float canvasX = (float) (pdfX * finalScale);
+        // Y-axis inversion for TOP-LEFT corner of image
+        float canvasY = (float) ((pageHeight - pdfY - pdfHeight) * finalScale);
+        float canvasWidth = (float) (pdfWidth * finalScale);
+        float canvasHeight = (float) (pdfHeight * finalScale);
+
+        /*
+        logger.trace("PDF rect ({:.2f},{:.2f})+{:.2f}x{:.2f} → Canvas ({:.2f},{:.2f})+{:.2f}x{:.2f}",
+                pdfX, pdfY, pdfWidth, pdfHeight,
+                canvasX, canvasY, canvasWidth, canvasHeight);
+         */
+        return new Rectangle2D.Float(canvasX, canvasY, canvasWidth, canvasHeight);
+    }
+
     /**
      * Validates if PDF coordinates are within page bounds.
-     * 
+     *
      * @param pdfX X coordinate in PDF points
      * @param pdfY Y coordinate in PDF points
      * @param pageWidth Page width in points
      * @param pageHeight Page height in points
      * @return true if coordinates are valid
      */
-    public static boolean isValidPdfCoordinate(float pdfX, float pdfY, 
-                                                float pageWidth, float pageHeight) {
-        boolean valid = pdfX >= 0 && pdfX <= pageWidth && 
-                       pdfY >= 0 && pdfY <= pageHeight;
-        
+    public static boolean isValidPdfCoordinate(float pdfX, float pdfY,
+            float pageWidth, float pageHeight) {
+        boolean valid = pdfX >= 0 && pdfX <= pageWidth
+                && pdfY >= 0 && pdfY <= pageHeight;
+
         if (!valid) {
-            logger.warn("Invalid PDF coordinates: ({:.2f},{:.2f}) outside bounds (0,0)-({:.2f},{:.2f})",
-                    pdfX, pdfY, pageWidth, pageHeight);
+            //logger.warn("Invalid PDF coordinates: ({:.2f},{:.2f}) outside bounds (0,0)-({:.2f},{:.2f})",pdfX, pdfY, pageWidth, pageHeight);
         }
-        
+
         return valid;
     }
 }

--- a/src/main/java/org/pdflite/util/ImageExtractor.java
+++ b/src/main/java/org/pdflite/util/ImageExtractor.java
@@ -1,0 +1,129 @@
+package org.pdflite.util;
+
+import org.apache.pdfbox.contentstream.PDFStreamEngine;
+import org.apache.pdfbox.contentstream.operator.Operator;
+import org.apache.pdfbox.contentstream.operator.DrawObject;
+import org.apache.pdfbox.contentstream.operator.state.*;
+import org.apache.pdfbox.contentstream.operator.graphics.*;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.graphics.PDXObject;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.util.Matrix;
+import org.pdflite.model.ImageInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p><b>Critical Fix:</b> Registers ALL graphics state operators
+ * to ensure CTM is tracked correctly before 'Do' operator.</p>
+ * 
+ * @see <a href="../../../docs/knowledge_3.md">Knowledge Base - Matrix Tracking</a>
+ */
+public class ImageExtractor extends PDFStreamEngine {
+    private static final Logger logger = LoggerFactory.getLogger(ImageExtractor.class);
+    
+    private final List<ImageInfo> images = new ArrayList<>();
+    private int currentPageIndex;
+
+    public ImageExtractor() throws IOException {
+        addOperator(new DrawObject(this));
+        addOperator(new Concatenate(this));
+        addOperator(new Save(this));
+        addOperator(new Restore(this));
+        addOperator(new SetGraphicsStateParameters(this));
+        addOperator(new SetMatrix(this));
+    }
+    
+    /**
+     * Extracts all images from a PDF page.
+     * @param page
+     * @param pageIndex
+     * @return 
+     * @throws java.io.IOException
+     */
+    public List<ImageInfo> extractImages(PDPage page, int pageIndex) throws IOException {
+        this.currentPageIndex = pageIndex;
+        this.images.clear();
+        processPage(page);
+        return new ArrayList<>(images);
+    }
+    
+    /**
+     *
+     * @param operator
+     * @param operands
+     * @throws java.io.IOException
+     */
+    @Override
+    protected void processOperator(Operator operator, List<COSBase> operands) 
+            throws IOException {
+        
+        String operatorName = operator.getName();
+        
+        if ("Do".equals(operatorName)) {
+            COSName objectName = (COSName) operands.get(0);
+            PDXObject xobject = getResources().getXObject(objectName);
+            
+            if (xobject instanceof PDImageXObject) {
+                processImageXObject((PDImageXObject) xobject, objectName.getName());
+                
+            } else if (xobject instanceof PDFormXObject) {
+                PDFormXObject form = (PDFormXObject) xobject;
+                showForm(form);
+            }
+        } else {
+            super.processOperator(operator, operands);
+        }
+    }
+    
+    /**
+     * Extract image with position from CTM.
+     */
+    private void processImageXObject(PDImageXObject pdImage, String name) throws IOException {
+        // Get CTM (now contains REAL transformation values!)
+        Matrix ctm = getGraphicsState().getCurrentTransformationMatrix();
+        
+        // Extract position
+        float xPosition = ctm.getTranslateX();
+        float yPosition = ctm.getTranslateY();
+        
+        // Extract rendered size (scaled dimensions)
+        float renderedWidth = Math.abs(ctm.getScaleX());
+        float renderedHeight = Math.abs(ctm.getScaleY());
+        
+        // Validate extracted values
+        if (xPosition == 0 && yPosition == 0 && renderedWidth == 1 && renderedHeight == 1) {
+            logger.warn("Image '{}' has identity CTM - may indicate missing matrix tracking!", name);
+        }
+        
+        // Get pixel data
+        BufferedImage bufferedImage = pdImage.getImage();
+        
+        // Create ImageInfo
+        ImageInfo imageInfo = new ImageInfo(
+            currentPageIndex,
+            xPosition,
+            yPosition,
+            renderedWidth,
+            renderedHeight,
+            bufferedImage
+        );
+        
+        images.add(imageInfo);
+        /*
+        logger.debug("Image '{}' extracted:", name);
+        logger.debug("Position (PDF Y=bottom): ({:.2f}, {:.2f}) pt", xPosition, yPosition);
+        logger.debug("Rendered Size: {:.2f} x {:.2f} pt", renderedWidth, renderedHeight);
+        logger.debug("Pixel Size: {} x {} px", 
+            bufferedImage.getWidth(), bufferedImage.getHeight());
+         */
+    }
+}

--- a/src/main/java/org/pdflite/view/ContextMenuPane.java
+++ b/src/main/java/org/pdflite/view/ContextMenuPane.java
@@ -56,42 +56,68 @@ public class ContextMenuPane extends StackPane {
     }
 
     private void setupEventHandlers() {
-        setOnMousePressed(this::handleMousePressed);
-        setOnMouseDragged(this::handleMouseDragged);
-        setOnMouseReleased(this::handleMouseReleased);
-    }
-    
-    private void handleMousePressed(MouseEvent event) {
-        if (event.getButton() == MouseButton.PRIMARY) {
-            isSelecting = true;
-            
-            // Store local coordinates
-            selectionStartX = event.getX();
-            selectionStartY = event.getY();
-            
-            // Initialize rectangle at position
-            selectionRect.setX(selectionStartX);
-            selectionRect.setY(selectionStartY);
-            selectionRect.setWidth(0);
-            selectionRect.setHeight(0);
-            selectionRect.setVisible(true);
-            
-            logger.debug("Selection START at LOCAL ({:.1f}, {:.1f})", 
-                selectionStartX, selectionStartY);
-            
-            event.consume();
-            return;
+    setOnMousePressed(this::handleMousePressed);
+    setOnMouseDragged(this::handleMouseDragged);
+    setOnMouseReleased(this::handleMouseReleased);
+    setOnContextMenuRequested(event -> {
+        double x = event.getX();
+        double y = event.getY();
+        
+        //logger.debug("Context menu requested at ({:.1f}, {:.1f})", x, y);
+        
+        // Check for image at cursor
+        handler.analyzeCursorForImage(
+            currentDocument,
+            currentPageIndex,
+            x, y,
+            currentZoom
+        );
+        
+        // Check for text selection
+        boolean hasSelection = selectionRect.isVisible() && 
+                              selectionRect.getWidth() >= MIN_SELECTION_SIZE &&
+                              selectionRect.getHeight() >= MIN_SELECTION_SIZE;
+        
+        // Show menu if has text OR image
+        if (hasSelection || handler.hasImageAtPosition()) {
+            updateContextMenuItems();
+            contextMenu.show(this, event.getScreenX(), event.getScreenY());
+            //logger.info("Context menu shown (hasText={}, hasImage={})",hasSelection, handler.hasImageAtPosition());
+        } else {
+            logger.warn("Context menu blocked: no text or image");
         }
         
-        if (event.getButton() == MouseButton.SECONDARY) {
-            if (selectionRect.isVisible() && 
-                selectionRect.getWidth() >= MIN_SELECTION_SIZE &&
-                selectionRect.getHeight() >= MIN_SELECTION_SIZE) {
-                showContextMenuForSelection(event);
-            }
-            event.consume();
-        }
+        event.consume();
+    });
+}
+    
+    private void handleMousePressed(MouseEvent event) {
+    // LEFT CLICK: Start selection
+    if (event.getButton() == MouseButton.PRIMARY) {
+        isSelecting = true;
+        
+        selectionStartX = event.getX();
+        selectionStartY = event.getY();
+        
+        selectionRect.setX(selectionStartX);
+        selectionRect.setY(selectionStartY);
+        selectionRect.setWidth(0);
+        selectionRect.setHeight(0);
+        selectionRect.setVisible(true);
+        
+        //logger.debug("Selection START at ({:.1f}, {:.1f})",selectionStartX, selectionStartY);
+        
+        event.consume();
+        return;
     }
+    
+    // RIGHT CLICK: Fallback (if setOnContextMenuRequested doesn't work)
+    if (event.getButton() == MouseButton.SECONDARY) {
+        //logger.debug("RIGHT CLICK detected at ({:.1f}, {:.1f})",event.getX(), event.getY());
+        // Let setOnContextMenuRequested handle it
+        event.consume();
+    }
+}
     
     private void handleMouseDragged(MouseEvent event) {
         if (isSelecting) {
@@ -132,7 +158,7 @@ public class ContextMenuPane extends StackPane {
         double height = selectionRect.getHeight();
         
         if (width < MIN_SELECTION_SIZE || height < MIN_SELECTION_SIZE) {
-            logger.debug("Selection too small ({:.1f}x{:.1f}), ignored", width, height);
+            //logger.debug("Selection too small ({:.1f}x{:.1f}), ignored", width, height);
             selectionRect.setVisible(false);
             return;
         }
@@ -156,50 +182,55 @@ public class ContextMenuPane extends StackPane {
         updateContextMenuItems();
         contextMenu.show(this, event.getScreenX(), event.getScreenY());
         
-        logger.info("Context menu shown");
+        //logger.info("Context menu shown");
     }
     
     private void setupContextMenu() {
         contextMenu = new ContextMenu();
-        
+
         MenuItem copyText = new MenuItem("Copy Text");
         MenuItem copyImage = new MenuItem("Copy Image");
         MenuItem separator = new MenuItem("──────────");
         MenuItem clearSelection = new MenuItem("Clear Selection");
-        
+
         separator.setDisable(true);
-        
+
         copyText.setOnAction(e -> {
             handler.handleCopyText();
             clearSelection();
         });
-        
+
         copyImage.setOnAction(e -> {
-            logger.info("Copy Image - TODO");
+            handler.handleCopyImage();
+            logger.info("Image copied");
         });
-        
+
         clearSelection.setOnAction(e -> clearSelection());
-        
-        contextMenu.getItems().addAll(copyText, copyImage, separator, clearSelection);
+
+        contextMenu.getItems().addAll(copyText, copyImage, clearSelection);
     }
     
     private void updateContextMenuItems() {
         boolean hasText = handler.hasTextAtPosition();
-        contextMenu.getItems().get(0).setDisable(!hasText);
-        contextMenu.getItems().get(1).setDisable(true);
+        boolean hasImage = handler.hasImageAtPosition();
+
+        contextMenu.getItems().get(0).setDisable(!hasText);  // Copy Text
+        contextMenu.getItems().get(1).setDisable(!hasImage); // Copy Image
+
+        logger.debug("Context menu: text={}, image={}", hasText, hasImage);
     }
     
     public void setDocumentInfo(PDFDocument document, int pageIndex, double zoom) {
+        boolean pageChanged = (this.currentPageIndex != pageIndex);
+
         this.currentDocument = document;
         this.currentPageIndex = pageIndex;
         this.currentZoom = zoom;
-        
-        /**
-        logger.debug("Document info: Page {}/{}, Zoom {:.0f}%",
-            pageIndex + 1, 
-            document != null ? document.getTotalPages() : 0,
-            zoom * 100);
-        */
+
+        // Clear image cache when page changes
+        if (pageChanged) {
+            handler.clearImageCache();
+        }
     }
     
     public void clearSelection() {


### PR DESCRIPTION
# Changelog
Triển khai chức năng **Image Extract/Copy** bằng thao tác chuột phải trong Context Menu.

## Hoạt động
- Chuột phải vào hình ảnh trong tài liệu PDF để mở Context Menu.
- Chọn "Copy Image" để sao chép hình ảnh vào clipboard.
- Vẫn có thể dùng Copy Image khi Zoom In/Out.

## File Changed
- ADD: ImageInfo.java
- ADD: ImageExtractor.java
- MOD: PageRenderer.java
- MOD: CoordinateConverter.java
- MOD: ContextMenuPane.java
- MOD: ContextMenuHandler.java

## BUGS/KNOWN ISSUES
- Đôi lúc bị lỗi Cache khi sao chép ảnh ở trang tiếp theo.
    Tái hiện bug: Trang trước đó có nhiều ảnh, trang hiện tại có ít ảnh hơn, khi sao chép ảnh ở trang hiện tại sẽ bị lỗi Cache thành ảnh của trang trước đó.
    Lỗi cũng làm context menu enable cho Copy Image ở mọi vị trí trên trang, dù không có ảnh.
    Chú thích: Không tái hiện lỗi được ở file PDF lớn, các file PDF nhỏ từ 2-3 trang dễ tái hiện lỗi hơn. 
- Chưa hỗ trợ sao chép nhiều hình ảnh cùng lúc.
