### PR TITLE
fix: optimize memory usage and improve performance at high zoom levels

### DIFF
--- a/src/main/java/org/pdflite/controller/PageRenderer.java
+++ b/src/main/java/org/pdflite/controller/PageRenderer.java
@@ -76,14 +76,40 @@ public class PageRenderer {
         }
         this.currentDocument = document;
         this.currentZoom = zoom;
+        adjustCacheSizeForZoom(zoom);
         logger.info("PageRenderer: Document set with zoom {}", zoom);
     }
 
     /**
      * Sets the zoom level.
+     * Adjusts cache size based on zoom to prevent memory issues at high zoom.
      */
     public void setZoom(double zoom) {
         this.currentZoom = zoom;
+        adjustCacheSizeForZoom(zoom);
+    }
+
+    /**
+     * Adjusts cache size based on the zoom level.
+     * At high zoom levels, reduce cache size to prevent memory issues.
+     */
+    private void adjustCacheSizeForZoom(double zoom) {
+        int maxCacheSize;
+        if (zoom >= 1.5) {
+            maxCacheSize = 20; // Very high zoom: small cache
+        } else if (zoom >= 1.2) {
+            maxCacheSize = 30; // High zoom: medium cache
+        } else {
+            maxCacheSize = 50; // Normal zoom: full cache
+        }
+
+        // Trim cache if it exceeds the new limit
+        // Removing from cache allows JavaFX to garbage collect the Image
+        while (imageCache.size() > maxCacheSize) {
+            String oldestKey = imageCache.keySet().iterator().next();
+            imageCache.remove(oldestKey);
+            logger.debug("Removed image from cache to maintain size limit: {}", oldestKey);
+        }
     }
 
     /**
@@ -322,6 +348,47 @@ public class PageRenderer {
 
         pageBox.getChildren().add(placeholder);
         return pageBox;
+    }
+
+    /**
+     * Unloads a page by replacing it with a placeholder.
+     * This helps free memory when pages are far from the viewport at high zoom levels.
+     *
+     * @param pageIndex the index of the page to unload
+     * @param pageBox   the page box containing the rendered page
+     */
+    public void unloadPage(int pageIndex, VBox pageBox) {
+        if (pageBox == null || pageBox.getChildren().isEmpty()) {
+            return;
+        }
+
+        // Only unload if it's actually rendered (has ImageView)
+        Object firstChild = pageBox.getChildren().getFirst();
+        if (!(firstChild instanceof StackPane stackPane)) {
+            return;
+        }
+
+        boolean hasImageView = stackPane.getChildren().stream()
+                .anyMatch(child -> child instanceof ImageView);
+        if (!hasImageView) {
+            return; // Already a placeholder
+        }
+
+        // Get page dimensions before unloading
+        double width = pageBox.getPrefWidth();
+        double height = pageBox.getPrefHeight();
+
+        // Replace with placeholder
+        StackPane placeholder = new StackPane();
+        placeholder.setPrefSize(width, height);
+        placeholder.setMinSize(width, height);
+        placeholder.setMaxSize(width, height);
+        placeholder.setStyle("-fx-background-color: #606060; -fx-padding: 0;");
+
+        Platform.runLater(() -> {
+            pageBox.getChildren().set(0, placeholder);
+            logger.debug("Unloaded page {} to free memory", pageIndex + 1);
+        });
     }
 
     public void setSelectionModeActive(VBox pagesContainer, boolean active) {

--- a/src/main/java/org/pdflite/controller/ScrollHandler.java
+++ b/src/main/java/org/pdflite/controller/ScrollHandler.java
@@ -30,7 +30,7 @@ import javafx.scene.layout.VBox;
 public class ScrollHandler {
     private static final Logger logger = LoggerFactory.getLogger(ScrollHandler.class);
 
-    private static final long SCROLL_DEBOUNCE_MS = 50; // Wait 50ms after scroll stops
+    private static final long SCROLL_DEBOUNCE_MS = 100; // Wait 100 ms after scroll stops (increased to reduce load frequency)
 
     private final PageRenderer pageRenderer;
     private final ScrollPane scrollPane;
@@ -108,6 +108,7 @@ public class ScrollHandler {
 
     /**
      * Loads pages that are currently visible or near the viewport.
+     * Optimized for high zoom levels to prevent lag.
      */
     private void loadVisiblePages() {
         if (currentDocument == null || pagesContainer == null || scrollPane == null) {
@@ -121,16 +122,16 @@ public class ScrollHandler {
 
         Platform.runLater(() -> {
             try {
-                double bufferSize = scrollPane.getViewportBounds().getHeight();
+                double viewportHeight = scrollPane.getViewportBounds().getHeight();
                 double scrollValue = scrollPane.getVvalue();
 
                 int totalPages = currentDocument.getTotalPages();
+                double currentZoom = currentDocument.getZoomLevel();
 
                 // Calculate total content height based on all page placeholders
-                // This ensures accurate calculation even when pages haven't been rendered yet
                 double contentHeight = getContentHeight(totalPages);
 
-                if (contentHeight <= bufferSize) {
+                if (contentHeight <= viewportHeight) {
                     // All content is visible, load all pages
                     for (int i = 0; i < totalPages; i++) {
                         if (pageRenderer.isPageLoading(i)) {
@@ -144,10 +145,17 @@ public class ScrollHandler {
                 }
 
                 // Calculate visible range
-                double visibleStart = scrollValue * (contentHeight - bufferSize);
-                double visibleEnd = visibleStart + bufferSize;
+                double visibleStart = scrollValue * (contentHeight - viewportHeight);
+                double visibleEnd = visibleStart + viewportHeight;
 
-                // Add a buffer zone (1 viewport above and below for smooth scrolling)
+                // Adaptive buffer zone: reduce buffer to prevent lag
+                // Smaller buffer = fewer pages loaded = less lag
+                // At 100% zoom: 0.5 viewport buffer (reduced from 1.0)
+                // At 120%+ zoom: 0.3 viewport buffer
+                // At 150%+ zoom: 0.2 viewport buffer
+                double bufferMultiplier = currentZoom >= 1.5 ? 0.2 : (currentZoom >= 1.2 ? 0.3 : 0.5);
+                double bufferSize = viewportHeight * bufferMultiplier;
+
                 double loadStart = Math.max(0, visibleStart - bufferSize);
                 double loadEnd = Math.min(contentHeight, visibleEnd + bufferSize);
 
@@ -157,14 +165,11 @@ public class ScrollHandler {
                 Set<Integer> pagesInRange = new HashSet<>();
 
                 for (int i = 0; i < totalPages; i++) {
-                    // Safety check: ensure the page box exists
                     ScrollCalculator.PageBounds bounds = ScrollCalculator.calculatePageBounds(pagesContainer, i);
 
-                    // Check if the page is in load range
                     if (bounds.overlaps(loadStart, loadEnd)) {
                         pagesInRange.add(i);
 
-                        // Prioritize visible pages over buffer pages
                         if (bounds.overlaps(visibleStart, visibleEnd)) {
                             visiblePages.add(i);
                         } else {
@@ -178,33 +183,45 @@ public class ScrollHandler {
                     pageRenderer.cancelOutOfRangePendingRenders(pagesInRange);
                 }
 
+                // Limit concurrent page loads to prevent lag
+                // Always limit, not just at high zoom
+                int maxConcurrentLoads = currentZoom >= 1.5 ? 2 : (currentZoom >= 1.2 ? 3 : 5);
+                int loadedCount = 0;
+
                 // Load visible pages first (high priority)
-                for (int pageIndex : visiblePages) {
-                    if (pageRenderer.isPageLoading(pageIndex)) {
-                        VBox pageBox = getPageBox(pageIndex);
-                        if (pageBox != null && isPlaceholder(pageBox)) {
-                            pageRenderer.loadPage(pageIndex, pageBox);
+                loadedCount = loadPagesInList(visiblePages, maxConcurrentLoads, loadedCount);
+
+                // Then load nearby pages (lower priority) - only if we haven't hit the limit
+                loadedCount = loadPagesInList(nearbyPages, maxConcurrentLoads, loadedCount);
+
+                // Always unload pages far from the viewport to prevent lag
+                // Adaptive unload distance based on zoom
+                double unloadDistance = currentZoom >= 1.5 ? viewportHeight :
+                                       (currentZoom >= 1.2 ? viewportHeight * 1.5 : viewportHeight * 2.0);
+                double unloadStart = Math.max(0, visibleStart - unloadDistance);
+                double unloadEnd = Math.min(contentHeight, visibleEnd + unloadDistance);
+
+                // Unload pages outside the keep range
+                for (int i = 0; i < totalPages; i++) {
+                    ScrollCalculator.PageBounds bounds = ScrollCalculator.calculatePageBounds(pagesContainer, i);
+                    if (!bounds.overlaps(unloadStart, unloadEnd)) {
+                        // Page is far from viewport, unload it
+                        VBox pageBox = getPageBox(i);
+                        if (pageBox != null && !isPlaceholder(pageBox)) {
+                            pageRenderer.unloadPage(i, pageBox);
                         }
                     }
                 }
 
-                // Then load nearby pages (lower priority)
-                for (int pageIndex : nearbyPages) {
-                    if (pageRenderer.isPageLoading(pageIndex)) {
-                        VBox pageBox = getPageBox(pageIndex);
-                        if (pageBox != null && isPlaceholder(pageBox)) {
-                            pageRenderer.loadPage(pageIndex, pageBox);
-                        }
-                    }
-                }
-
-                // Additional safeguard: if we're near the end (last 5 pages), ensure they get loaded
-                if (scrollValue > 0.8 && totalPages > 0) {
-                    int startPage = Math.max(0, totalPages - 5);
+                // Additional safeguard: if we're near the end (last 3 pages), ensure they get loaded
+                if (scrollValue > 0.85 && totalPages > 0 && loadedCount < maxConcurrentLoads) {
+                    int startPage = Math.max(0, totalPages - 3);
                     for (int i = startPage; i < totalPages; i++) {
+                        if (loadedCount >= maxConcurrentLoads) break;
                         VBox pageBox = getPageBox(i);
                         if (pageBox != null && pageRenderer.isPageLoading(i) && isPlaceholder(pageBox)) {
                             pageRenderer.loadPage(i, pageBox);
+                            loadedCount++;
                         }
                     }
                 }
@@ -213,6 +230,29 @@ public class ScrollHandler {
                 logger.error("Error loading visible pages", e);
             }
         });
+    }
+
+    /**
+     * Loads pages from a list up to the maximum concurrent load limit.
+     *
+     * @param pageList         the list of page indices to load
+     * @param maxConcurrentLoads the maximum number of pages to load
+     * @param currentLoadedCount the current count of loaded pages
+     * @return the updated count of loaded pages
+     */
+    private int loadPagesInList(List<Integer> pageList, int maxConcurrentLoads, int currentLoadedCount) {
+        int loadedCount = currentLoadedCount;
+        for (int pageIndex : pageList) {
+            if (loadedCount >= maxConcurrentLoads) break;
+            if (pageRenderer.isPageLoading(pageIndex)) {
+                VBox pageBox = getPageBox(pageIndex);
+                if (pageBox != null && isPlaceholder(pageBox)) {
+                    pageRenderer.loadPage(pageIndex, pageBox);
+                    loadedCount++;
+                }
+            }
+        }
+        return loadedCount;
     }
 
     private double getContentHeight(int totalPages) {

--- a/src/main/java/org/pdflite/util/Constants.java
+++ b/src/main/java/org/pdflite/util/Constants.java
@@ -100,6 +100,16 @@ public class Constants {
     public static final double HIGH_RENDER_SCALE = 300.0 / 72.0; //HIGH DPI RENDERING SCALE
 
     /**
+     * Maximum canvas size to prevent GPU texture overflow.
+     * <p>
+     * JavaFX Canvas uses GPU textures which have size limits (typically 4096x4096 or 8192x8192).
+     * When canvas exceeds this limit, RTTexture.createGraphics() returns null causing NullPointerException.
+     * This constant limits canvas dimensions to prevent such errors.
+     * </p>
+     */
+    public static final double MAX_CANVAS_SIZE = 4096.0;
+
+    /**
      * Private constructor to prevent instantiation.
      * <p>
      * This is a utility class containing only static constants and should

--- a/src/main/java/org/pdflite/view/AnnotationLayer.java
+++ b/src/main/java/org/pdflite/view/AnnotationLayer.java
@@ -97,14 +97,29 @@ public class AnnotationLayer extends Canvas {
      * The dimensions should match the rendered PDF page image dimensions
      * to ensure proper alignment of annotations.
      * </p>
+     * <p>
+     * Canvas dimensions are clamped to MAX_CANVAS_SIZE to prevent GPU texture overflow
+     * which causes NullPointerException when creating GraphicsContext.
+     * </p>
      *
      * @param width  the width of the layer in pixels
      * @param height the height of the layer in pixels
      */
     public AnnotationLayer(double width, double height) {
-        super(width, height);
+        // Clamp dimensions to prevent GPU texture overflow
+        // Must call super() first for Java 21 compatibility
+        super(Math.min(width, Constants.MAX_CANVAS_SIZE), Math.min(height, Constants.MAX_CANVAS_SIZE));
+        
+        // Check if clamping occurred and log warning
+        double clampedWidth = Math.min(width, Constants.MAX_CANVAS_SIZE);
+        double clampedHeight = Math.min(height, Constants.MAX_CANVAS_SIZE);
+        if (width != clampedWidth || height != clampedHeight) {
+            logger.warn("AnnotationLayer dimensions {}x{} clamped to {}x{} to prevent GPU texture overflow",
+                    width, height, clampedWidth, clampedHeight);
+        }
+        
         setupMouseHandlers();
-        logger.debug("AnnotationLayer created: {}x{}", width, height);
+        logger.debug("AnnotationLayer created: {}x{}", clampedWidth, clampedHeight);
     }
 
     public void setPageIndex(int index) {
@@ -179,13 +194,21 @@ public class AnnotationLayer extends Canvas {
 
             if (currentMode == AnnotationMode.HIGHLIGHT) {
                 redraw();
-                GraphicsContext gc = getGraphicsContext2D();
-                gc.setFill(getColorWithAlpha(currentColor, 0.4));
-                double x = Math.min(startX, event.getX());
-                double y = Math.min(startY, event.getY());
-                double w = Math.abs(event.getX() - startX);
-                double h = Math.abs(event.getY() - startY);
-                gc.fillRect(x, y, w, h);
+                try {
+                    GraphicsContext gc = getGraphicsContext2D();
+                    if (gc == null) {
+                        logger.warn("Cannot draw highlight - GraphicsContext is null (canvas too large)");
+                        return;
+                    }
+                    gc.setFill(getColorWithAlpha(currentColor, 0.4));
+                    double x = Math.min(startX, event.getX());
+                    double y = Math.min(startY, event.getY());
+                    double w = Math.abs(event.getX() - startX);
+                    double h = Math.abs(event.getY() - startY);
+                    gc.fillRect(x, y, w, h);
+                } catch (NullPointerException e) {
+                    logger.warn("Cannot draw highlight - canvas too large", e);
+                }
             } else {
                 switch (currentMode) {
                     case RECTANGLE:
@@ -235,8 +258,8 @@ public class AnnotationLayer extends Canvas {
      * Adds a highlight annotation to the layer.
      * <p>
      * This method creates a {@link HighlightAnnotation} from the given coordinates
-     * and adds it to the annotations list. The coordinates are normalized so that
-     * (x, y) represents the top-left corner. Highlights with dimensions smaller
+     * and adds it to the annotation list. The coordinates are normalized so that
+     * (x, y) represent the top-left corner. Highlights with dimensions smaller
      * than 5x5 pixels are ignored to prevent accidental tiny highlights.
      * </p>
      *
@@ -265,25 +288,43 @@ public class AnnotationLayer extends Canvas {
      * It should be called whenever the annotation list changes or when the
      * layer needs to be refreshed.
      * </p>
+     * <p>
+     * Handles GPU texture overflow gracefully by catching NullPointerException
+     * when GraphicsContext cannot be created (canvas too large).
+     * </p>
      */
     public void redraw() {
-        GraphicsContext gc = getGraphicsContext2D();
-        gc.clearRect(0, 0, getWidth(), getHeight());
-        drawSearchHighlights(gc);
-        for (Annotation annotation : annotations) {
-            if (annotation instanceof HighlightAnnotation highlight) {
-                gc.setFill(getColorWithAlpha(highlight.getColor(), 0.4));
-                gc.fillRect(highlight.getX(), highlight.getY(),
-                        highlight.getWidth(), highlight.getHeight());
-            } else if (annotation instanceof ShapeAnnotation shape) {
-                shape.draw(gc, scale);
+        try {
+            GraphicsContext gc = getGraphicsContext2D();
+            if (gc == null) {
+                logger.error("Failed to get GraphicsContext2D - canvas may be too large ({}x{})",
+                        getWidth(), getHeight());
+                return;
             }
-        }
+            
+            gc.clearRect(0, 0, getWidth(), getHeight());
+            drawSearchHighlights(gc);
+            for (Annotation annotation : annotations) {
+                if (annotation instanceof HighlightAnnotation highlight) {
+                    gc.setFill(getColorWithAlpha(highlight.getColor(), 0.4));
+                    gc.fillRect(highlight.getX(), highlight.getY(),
+                            highlight.getWidth(), highlight.getHeight());
+                } else if (annotation instanceof ShapeAnnotation shape) {
+                    shape.draw(gc, scale);
+                }
+            }
 
-        if (tempAnnotation instanceof ShapeAnnotation shapeTemp) {
-            gc.setLineDashes(5); // Nét đứt
-            shapeTemp.draw(gc, scale);
-            gc.setLineDashes(0); // Reset về nét liền
+            if (tempAnnotation instanceof ShapeAnnotation shapeTemp) {
+                gc.setLineDashes(5); // Nét đứt
+                shapeTemp.draw(gc, scale);
+                gc.setLineDashes(0); // Reset về nét liền
+            }
+        } catch (NullPointerException e) {
+            logger.error("NullPointerException in redraw() - canvas too large ({}x{}). " +
+                    "This usually happens when canvas exceeds GPU texture limit.",
+                    getWidth(), getHeight(), e);
+        } catch (Exception e) {
+            logger.error("Error redrawing annotations", e);
         }
     }
 
@@ -437,61 +478,65 @@ public class AnnotationLayer extends Canvas {
     }
 
     private void drawSearchHighlights(GraphicsContext gc) {
-        if (searchHighlights.isEmpty()) {
+        if (searchHighlights.isEmpty() || gc == null) {
             return;
         }
-
-        gc.save();
-
-        double canvasWidth = getWidth();
-        double canvasHeight = getHeight();
-
-        logger.trace("Drawing {} highlights on canvas {}x{} with scale={}",
-                searchHighlights.size(), canvasWidth, canvasHeight, scale);
 
         int normalCount = 0;
         int activeCount = 0;
 
-        for (SearchResult result : searchHighlights) {
-            if (result.width() <= 0 || result.height() <= 0) {
-                logger.warn("Invalid coordinates for search result: {}", result);
-                continue;
+        try {
+            gc.save();
+
+            double canvasWidth = getWidth();
+            double canvasHeight = getHeight();
+
+            logger.trace("Drawing {} highlights on canvas {}x{} with scale={}",
+                    searchHighlights.size(), canvasWidth, canvasHeight, scale);
+
+            for (SearchResult result : searchHighlights) {
+                if (result.width() <= 0 || result.height() <= 0) {
+                    logger.warn("Invalid coordinates for search result: {}", result);
+                    continue;
+                }
+
+                boolean isActive = (result.equals(activeSearchResult));
+
+                Color highlightColor = isActive ? ACTIVE_SEARCH_HIGHLIGHT_COLOR : SEARCH_HIGHLIGHT_COLOR;
+                double opacity = isActive ? ACTIVE_SEARCH_HIGHLIGHT_OPACITY : SEARCH_HIGHLIGHT_OPACITY;
+
+                gc.setFill(Color.color(
+                        highlightColor.getRed(),
+                        highlightColor.getGreen(),
+                        highlightColor.getBlue(),
+                        opacity
+                ));
+
+                double finalScale = this.scale * LOW_RENDER_SCALE;
+                double x = result.x() * finalScale;
+                double y = result.y() * finalScale;
+                double width = result.width() * finalScale;
+                double height = result.height() * finalScale;
+
+                gc.fillRect(x, y, width, height);
+
+                if (isActive) {
+                    gc.setStroke(Color.DARKORANGE);
+                    gc.setLineWidth(2);
+                    gc.strokeRect(x, y, width, height);
+                    activeCount++;
+
+                    logger.trace("Drew ACTIVE highlight at ({}, {}) size {}x{} - page={}, start={}",
+                            x, y, width, height, result.pageNumber(), result.startIndex());
+                } else {
+                    normalCount++;
+                }
             }
 
-            boolean isActive = (result.equals(activeSearchResult));
-
-            Color highlightColor = isActive ? ACTIVE_SEARCH_HIGHLIGHT_COLOR : SEARCH_HIGHLIGHT_COLOR;
-            double opacity = isActive ? ACTIVE_SEARCH_HIGHLIGHT_OPACITY : SEARCH_HIGHLIGHT_OPACITY;
-
-            gc.setFill(Color.color(
-                    highlightColor.getRed(),
-                    highlightColor.getGreen(),
-                    highlightColor.getBlue(),
-                    opacity
-            ));
-
-            double finalScale = this.scale * LOW_RENDER_SCALE;
-            double x = result.x() * finalScale;
-            double y = result.y() * finalScale;
-            double width = result.width() * finalScale;
-            double height = result.height() * finalScale;
-
-            gc.fillRect(x, y, width, height);
-
-            if (isActive) {
-                gc.setStroke(Color.DARKORANGE);
-                gc.setLineWidth(2);
-                gc.strokeRect(x, y, width, height);
-                activeCount++;
-
-                logger.trace("Drew ACTIVE highlight at ({}, {}) size {}x{} - page={}, start={}",
-                        x, y, width, height, result.pageNumber(), result.startIndex());
-            } else {
-                normalCount++;
-            }
+            gc.restore();
+        } catch (Exception e) {
+            logger.error("Error drawing search highlights", e);
         }
-
-        gc.restore();
 
         if (activeCount > 1) {
             logger.warn("⚠️ Multiple active highlights detected! Count: {}", activeCount);


### PR DESCRIPTION
- Adjust cache size dynamically based on zoom level to prevent memory overflow.
- Refactor `loadVisiblePages` to reduce viewport buffer size at high zoom for performance.
- Unload pages distant from the viewport based on zoom, freeing resources.
- Clamp canvas dimensions to prevent GPU texture overflow and handled related exceptions.
- Enhance annotation layer and search highlight handling for large canvas sizes.